### PR TITLE
Omit "itemprop"-attribute if no value provided

### DIFF
--- a/QRCode/core/components/ludwigqrcode/elements/chunks/qrcode.chunk.tpl
+++ b/QRCode/core/components/ludwigqrcode/elements/chunks/qrcode.chunk.tpl
@@ -1,1 +1,1 @@
-<img src="[[+src]]" width="[[+width]]" height="[[+height]]" title="[[+title]]" alt="[[+alt]]" itemprop="[[+itemprop]]" />
+<img src="[[+src]]" width="[[+width]]" height="[[+height]]" title="[[+title]]" alt="[[+alt]]" [[+itemprop:isnotempty=`itemprop="[[+itemprop]]"`]] />


### PR DESCRIPTION
Takes care of an issue. Fixes #3 